### PR TITLE
Add `Whitespace` pre-tokenizer

### DIFF
--- a/Sources/Tokenizers/Tokenizers.swift
+++ b/Sources/Tokenizers/Tokenizers.swift
@@ -355,3 +355,12 @@ public class BPETrainer {
             endOfWordSuffix: endOfWordSuffix)
     }
 }
+
+//MARK:- Pre-Tokenizers
+
+/// This pre-tokenizer simply splits using the following regex: `\w+|[^\w\s]+`
+public class Whitespace {
+    let pre_tokenizer = RustWhitespace()
+
+    public init() {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,17 @@
 pub mod error;
 pub mod models;
+pub mod pre_tokenizers;
 pub mod tokenizer;
 pub mod trainers;
+mod utils;
 pub use crate::error::TokenizersError;
 pub use crate::models::bpe::{
     bpe_read_file as models_bpe_bpe_read_file, RustBpe, RustBpeReadFileReturn,
 };
+pub use crate::pre_tokenizers::{RustPreTokenizedString, RustWhitespace};
 pub use crate::tokenizer::{RustAddedToken, RustEncoding, RustTokenizer};
 pub use crate::trainers::RustBpeTrainer;
-pub use tokenizers::models::bpe::Merges as RustMerges;
+pub use crate::utils::{RustMerges, RustOffsets};
 use uniffi_macros;
 
 uniffi_macros::include_scaffolding!("lib");

--- a/src/lib.udl
+++ b/src/lib.udl
@@ -70,6 +70,15 @@ interface RustBpe {
   string? get_unk_token();
 };
 
+// Pre-Tokenizers
+interface RustPreTokenizedString {
+  constructor([ByRef] string content);
+};
+
+interface RustWhitespace {
+  constructor();
+};
+
 // Trainers
 interface RustBpeTrainer {
   [Throws=TokenizersError]

--- a/src/models/bpe.rs
+++ b/src/models/bpe.rs
@@ -1,38 +1,8 @@
 use crate::error::{Result, TokenizersError};
-use crate::UniffiCustomTypeConverter;
+use crate::utils::RustMerges;
 use std::sync::Arc;
 use tk::models::bpe::{Vocab, BPE};
 use tokenizers as tk;
-
-impl UniffiCustomTypeConverter for tk::models::bpe::Merges {
-    type Builtin = Vec<Vec<String>>;
-
-    fn into_custom(v_merges: Self::Builtin) -> uniffi::Result<Self>
-    where
-        Self: Sized,
-    {
-        let mut merges: tk::models::bpe::Merges = vec![];
-
-        for (i, m) in v_merges.iter().enumerate() {
-            if m.len() != 2 {
-                return Err(TokenizersError::ValueError(format!(
-                    "The element #{} in `merges` must be a list containing 2 elements but was {}",
-                    i,
-                    m.len()
-                ))
-                .into());
-            }
-
-            merges.push((m[0].clone(), m[1].clone()));
-        }
-
-        Ok(merges)
-    }
-
-    fn from_custom(obj: Self) -> Self::Builtin {
-        obj.iter().map(|m| vec![m.0.clone(), m.1.clone()]).collect()
-    }
-}
 
 pub struct RustBpe {
     model: Arc<tk::models::bpe::BPE>,
@@ -41,7 +11,7 @@ pub struct RustBpe {
 impl RustBpe {
     pub fn new(
         vocab: Option<tk::models::bpe::Vocab>,
-        merges: Option<tk::models::bpe::Merges>,
+        merges: Option<RustMerges>,
         vocab_file: Option<String>,
         merges_file: Option<String>,
         // UniFFI doesn't support usize type.

--- a/src/pre_tokenizers.rs
+++ b/src/pre_tokenizers.rs
@@ -1,0 +1,78 @@
+use std::sync::Arc;
+
+use crate::error::{Result, TokenizersError};
+use crate::utils::RustOffsets;
+use tk::{pre_tokenizers::whitespace::Whitespace, PreTokenizedString, PreTokenizer};
+use tokenizers as tk;
+
+/// PreTokenizedString
+///
+/// Wrapper over a string, that provides a way to normalize, pre-tokenize, tokenize the
+/// underlying string, while keeping track of the alignment information (offsets).
+///
+/// The PreTokenizedString manages what we call `splits`. Each split represents a substring
+/// which is a subpart of the original string, with the relevant offsets and tokens.
+///
+/// When calling one of the methods used to modify the PreTokenizedString (namely one of
+/// `split`, `normalize` or `tokenize), only the `splits` that don't have any associated
+/// tokens will get modified.
+///
+/// - Parameters:
+///     - sequence:
+///         The string sequence used to initialize this PreTokenizedString
+pub struct RustPreTokenizedString {
+    string: tk::PreTokenizedString,
+}
+
+impl From<PreTokenizedString> for RustPreTokenizedString {
+    fn from(string: PreTokenizedString) -> Self {
+        Self { string }
+    }
+}
+
+impl From<RustPreTokenizedString> for PreTokenizedString {
+    fn from(pre_tok: RustPreTokenizedString) -> Self {
+        pre_tok.string
+    }
+}
+
+impl RustPreTokenizedString {
+    pub fn new(s: &str) -> Self {
+        PreTokenizedString::from(s).into()
+    }
+}
+
+/// This pre-tokenizer simply splits using the following regex: `\w+|[^\w\s]+`
+pub struct RustWhitespace {
+    pre_tokenizer: Arc<Whitespace>,
+}
+
+impl PreTokenizer for RustWhitespace {
+    fn pre_tokenize(&self, normalized: &mut PreTokenizedString) -> tk::Result<()> {
+        self.pre_tokenizer.pre_tokenize(normalized)
+    }
+}
+
+impl RustWhitespace {
+    pub fn new() -> Self {
+        Self {
+            pre_tokenizer: Arc::new(Whitespace::default()),
+        }
+    }
+
+    pub fn pre_tokenize_str(&self, s: &str) -> Result<Vec<(String, RustOffsets)>> {
+        let mut pretokenized = tk::tokenizer::PreTokenizedString::from(s);
+
+        self.pre_tokenizer
+            .pre_tokenize(&mut pretokenized)
+            .map_err(|e| {
+                TokenizersError::Exception(format!("Error while pre-tokenizing: {}", e))
+            })?;
+
+        Ok(pretokenized
+            .get_splits(tk::OffsetReferential::Original, tk::OffsetType::Char)
+            .into_iter()
+            .map(|(s, o, _)| (s.to_owned(), o))
+            .collect())
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,63 @@
+use crate::error::TokenizersError;
+use crate::UniffiCustomTypeConverter;
+pub use tk::models::bpe::Merges as RustMerges;
+pub use tk::Offsets as RustOffsets;
+use tokenizers as tk;
+
+impl UniffiCustomTypeConverter for RustMerges {
+    type Builtin = Vec<Vec<String>>;
+
+    fn into_custom(v_merges: Self::Builtin) -> uniffi::Result<Self>
+    where
+        Self: Sized,
+    {
+        let mut merges: tk::models::bpe::Merges = vec![];
+
+        for (i, m) in v_merges.iter().enumerate() {
+            if m.len() != 2 {
+                return Err(TokenizersError::ValueError(format!(
+                    "The element #{} in `merges` must be a list containing 2 elements but was {}",
+                    i,
+                    m.len()
+                ))
+                .into());
+            }
+
+            merges.push((m[0].clone(), m[1].clone()));
+        }
+
+        Ok(merges)
+    }
+
+    fn from_custom(obj: Self) -> Self::Builtin {
+        obj.iter().map(|m| vec![m.0.clone(), m.1.clone()]).collect()
+    }
+}
+
+impl UniffiCustomTypeConverter for tk::Offsets {
+    type Builtin = Vec<u64>;
+
+    fn into_custom(value: Self::Builtin) -> uniffi::Result<Self>
+    where
+        Self: Sized,
+    {
+        if value.len() != 2 {
+            return Err(TokenizersError::ValueError(format!(
+                "The length of value must be 2 but was {}",
+                value.len()
+            ))
+            .into());
+        }
+
+        let start = usize::try_from(value[0])
+            .map_err(|e| TokenizersError::ValueError(format!("start offset: {}", e)))?;
+        let end = usize::try_from(value[1])
+            .map_err(|e| TokenizersError::ValueError(format!("end offset: {}", e)))?;
+
+        Ok((start, end))
+    }
+
+    fn from_custom(obj: Self) -> Self::Builtin {
+        vec![obj.0 as u64, obj.1 as u64]
+    }
+}


### PR DESCRIPTION
From [Quicktour](https://huggingface.co/docs/tokenizers/quicktour), I would like to make the code below work in tokenizer-swift.

```python
from tokenizers.pre_tokenizers import Whitespace
tokenizer.pre_tokenizer = Whitespace()
```