### PR TITLE
Add `Tokenizer.pre_tokenizer` property

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ tokenizers = "^0.13"
 uniffi = "0.21.0"
 uniffi_macros = "0.21.0"
 thiserror = "^1.0"
+serde = { version = "1.0", features = [ "derive", "rc" ] }
 
 [build-dependencies]
 uniffi_build = {version = "0.21.0", features = [ "builtin-bindgen" ]}

--- a/Sources/Tokenizers/Tokenizers.swift
+++ b/Sources/Tokenizers/Tokenizers.swift
@@ -3,6 +3,20 @@
 public class Tokenizer {
     let tokenizer: RustTokenizer
 
+    public var preTokenizer: Whitespace? {
+        get {
+            guard let unwrapped = self.tokenizer.getPreTokenizer() else { return nil }
+            return Whitespace(preTokenizer: unwrapped)
+        }
+        set(value) {
+            if let tok = value {
+                self.tokenizer.setPreTokenizer(preTokenizer: tok.preTokenizer)
+            } else {
+                fatalError("You cannot set preTokenizer to nil")
+            }
+        }
+    }
+
     /// Instantiate a new ``Tokenizer`` from an existing file on the
     /// Hugging Face Hub.
     ///
@@ -360,7 +374,13 @@ public class BPETrainer {
 
 /// This pre-tokenizer simply splits using the following regex: `\w+|[^\w\s]+`
 public class Whitespace {
-    let pre_tokenizer = RustWhitespace()
+    let preTokenizer: RustWhitespace
 
-    public init() {}
+    public convenience init() {
+        self.init(preTokenizer: RustWhitespace())
+    }
+
+    init(preTokenizer: RustWhitespace) {
+        self.preTokenizer = preTokenizer
+    }
 }

--- a/Sources/Tokenizers/Tokenizers.swift
+++ b/Sources/Tokenizers/Tokenizers.swift
@@ -17,6 +17,10 @@ public class Tokenizer {
         }
     }
 
+    public init(model: BPE) {
+        self.tokenizer = RustTokenizer(model: model.model)
+    }
+
     /// Instantiate a new ``Tokenizer`` from an existing file on the
     /// Hugging Face Hub.
     ///

--- a/src/lib.udl
+++ b/src/lib.udl
@@ -13,6 +13,8 @@ enum TokenizersError {
 };
 
 interface RustTokenizer {
+  constructor(RustBpe model);
+
   [Name=from_pretrained, Throws=TokenizersError]
   constructor(
     [ByRef] string identifier,

--- a/src/lib.udl
+++ b/src/lib.udl
@@ -21,6 +21,10 @@ interface RustTokenizer {
 
   [Throws=TokenizersError]
   RustEncoding encode([ByRef] string input, boolean add_special_tokens);
+
+  RustWhitespace? get_pre_tokenizer();
+
+  void set_pre_tokenizer(RustWhitespace pre_tokenizer);
 };
 
 interface RustEncoding {

--- a/src/models/bpe.rs
+++ b/src/models/bpe.rs
@@ -1,11 +1,49 @@
 use crate::error::{Result, TokenizersError};
 use crate::utils::RustMerges;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tk::models::bpe::{Vocab, BPE};
+use tk::models::bpe::{BpeTrainer, Vocab, BPE};
 use tokenizers as tk;
 
+#[derive(Clone, Serialize, Deserialize)]
 pub struct RustBpe {
     model: Arc<tk::models::bpe::BPE>,
+}
+
+impl tk::Model for RustBpe {
+    type Trainer = BpeTrainer;
+
+    fn tokenize(&self, sequence: &str) -> tk::Result<Vec<tk::Token>> {
+        self.model.tokenize(sequence)
+    }
+
+    fn token_to_id(&self, token: &str) -> Option<u32> {
+        self.model.token_to_id(token)
+    }
+
+    fn id_to_token(&self, id: u32) -> Option<String> {
+        self.model.id_to_token(id)
+    }
+
+    fn get_vocab(&self) -> std::collections::HashMap<String, u32> {
+        self.model.get_vocab()
+    }
+
+    fn get_vocab_size(&self) -> usize {
+        self.model.get_vocab_size()
+    }
+
+    fn save(
+        &self,
+        folder: &std::path::Path,
+        prefix: Option<&str>,
+    ) -> tk::Result<Vec<std::path::PathBuf>> {
+        self.model.save(folder, prefix)
+    }
+
+    fn get_trainer(&self) -> <Self as tk::Model>::Trainer {
+        self.model.get_trainer()
+    }
 }
 
 impl RustBpe {

--- a/src/pre_tokenizers.rs
+++ b/src/pre_tokenizers.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::error::{Result, TokenizersError};
 use crate::utils::RustOffsets;
+use serde::{Deserialize, Serialize};
 use tk::{pre_tokenizers::whitespace::Whitespace, PreTokenizedString, PreTokenizer};
 use tokenizers as tk;
 
@@ -41,7 +42,6 @@ impl RustPreTokenizedString {
         PreTokenizedString::from(s).into()
     }
 }
-use serde::{Deserialize, Serialize};
 
 /// This pre-tokenizer simply splits using the following regex: `\w+|[^\w\s]+`
 #[derive(Clone, Serialize, Deserialize)]

--- a/src/pre_tokenizers.rs
+++ b/src/pre_tokenizers.rs
@@ -41,8 +41,10 @@ impl RustPreTokenizedString {
         PreTokenizedString::from(s).into()
     }
 }
+use serde::{Deserialize, Serialize};
 
 /// This pre-tokenizer simply splits using the following regex: `\w+|[^\w\s]+`
+#[derive(Clone, Serialize, Deserialize)]
 pub struct RustWhitespace {
     pre_tokenizer: Arc<Whitespace>,
 }

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -4,7 +4,7 @@ use tk::AddedToken;
 use tokenizers as tk;
 
 pub struct RustTokenizer {
-    tokenizer: Arc<tk::tokenizer::Tokenizer>,
+    tokenizer: Arc<RwLock<tk::tokenizer::Tokenizer>>,
 }
 
 impl RustTokenizer {
@@ -24,13 +24,15 @@ impl RustTokenizer {
         let tokenizer = tk::tokenizer::Tokenizer::from_pretrained(identifier, Some(params))?;
 
         Ok(Self {
-            tokenizer: Arc::new(tokenizer),
+            tokenizer: Arc::new(RwLock::new(tokenizer)),
         })
     }
 
     pub fn encode(&self, input: &str, add_special_tokens: bool) -> Result<Arc<RustEncoding>> {
         let encoding = self
             .tokenizer
+            .read()
+            .unwrap()
             .encode_char_offsets(input, add_special_tokens)?;
 
         Ok(Arc::new(RustEncoding::new(Arc::new(encoding))))

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,26 +1,26 @@
-use crate::RustWhitespace;
+use crate::{RustBpe, RustWhitespace};
 
 use super::error::Result;
 use std::sync::{Arc, RwLock};
-use tk::{
-    AddedToken, DecoderWrapper, ModelWrapper, NormalizerWrapper, PostProcessorWrapper,
-    TokenizerImpl,
-};
+use tk::{AddedToken, DecoderWrapper, NormalizerWrapper, PostProcessorWrapper, TokenizerImpl};
 use tokenizers as tk;
 
-type Tokenizer = TokenizerImpl<
-    ModelWrapper,
-    NormalizerWrapper,
-    RustWhitespace,
-    PostProcessorWrapper,
-    DecoderWrapper,
->;
+type Tokenizer =
+    TokenizerImpl<RustBpe, NormalizerWrapper, RustWhitespace, PostProcessorWrapper, DecoderWrapper>;
 
 pub struct RustTokenizer {
     tokenizer: Arc<RwLock<Tokenizer>>,
 }
 
 impl RustTokenizer {
+    pub fn new(model: Arc<RustBpe>) -> Self {
+        let tokenizer = Tokenizer::new(model.as_ref().clone());
+
+        Self {
+            tokenizer: Arc::new(RwLock::new(tokenizer)),
+        }
+    }
+
     pub fn from_pretrained(
         identifier: &str,
         revision: String,


### PR DESCRIPTION
From [Quicktour](https://huggingface.co/docs/tokenizers/quicktour), I would like to make the code below work in tokenizer-swift.

```python
from tokenizers.pre_tokenizers import Whitespace
tokenizer.pre_tokenizer = Whitespace()
```