### PR TITLE
Add `Tokenizer.train()` method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ Footer
 .build.swiftsourceinfo
 Sources/Tokenizers/RustTokenizers.swift
 Sources/RustTokenizersFFI/include/RustTokenizersFFI.h
+/data

--- a/Sources/Tokenizers/Tokenizers.swift
+++ b/Sources/Tokenizers/Tokenizers.swift
@@ -81,6 +81,21 @@ public class Tokenizer {
         return Encoding(encoding)
     }
 
+    /// Train the Tokenizer using the given files.
+    ///
+    /// Reads the files line by line, while keeping all the whitespace, even new lines.
+    /// If you want to train from data store in-memory, you can check
+    /// ``train_from_iterator``
+    ///
+    /// - Parameters:
+    ///     - files:
+    ///         A list of path to the files that we should use for training
+    ///
+    ///     - trainer:
+    ///         An optional trainer that should be used to train our Model
+    public func train(files: [String], trainer: BPETrainer? = nil) throws {
+        try self.tokenizer.train(files: files, trainer: trainer?.trainer)
+    }
 }
 
 public struct Encoding {

--- a/src/lib.udl
+++ b/src/lib.udl
@@ -24,6 +24,9 @@ interface RustTokenizer {
   [Throws=TokenizersError]
   RustEncoding encode([ByRef] string input, boolean add_special_tokens);
 
+  [Throws=TokenizersError]
+  void train(sequence<string> files, RustBpeTrainer? trainer);
+
   RustWhitespace? get_pre_tokenizer();
 
   void set_pre_tokenizer(RustWhitespace pre_tokenizer);

--- a/src/models/bpe.rs
+++ b/src/models/bpe.rs
@@ -1,5 +1,6 @@
 use crate::error::{Result, TokenizersError};
 use crate::utils::RustMerges;
+use crate::RustBpeTrainer;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tk::models::bpe::{BpeTrainer, Vocab, BPE};
@@ -11,7 +12,7 @@ pub struct RustBpe {
 }
 
 impl tk::Model for RustBpe {
-    type Trainer = BpeTrainer;
+    type Trainer = RustBpeTrainer;
 
     fn tokenize(&self, sequence: &str) -> tk::Result<Vec<tk::Token>> {
         self.model.tokenize(sequence)

--- a/src/models/bpe.rs
+++ b/src/models/bpe.rs
@@ -2,36 +2,36 @@ use crate::error::{Result, TokenizersError};
 use crate::utils::RustMerges;
 use crate::RustBpeTrainer;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
-use tk::models::bpe::{BpeTrainer, Vocab, BPE};
+use std::sync::{Arc, RwLock};
+use tk::models::bpe::{Vocab, BPE};
 use tokenizers as tk;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct RustBpe {
-    model: Arc<tk::models::bpe::BPE>,
+    pub(crate) model: Arc<RwLock<tk::models::bpe::BPE>>,
 }
 
 impl tk::Model for RustBpe {
     type Trainer = RustBpeTrainer;
 
     fn tokenize(&self, sequence: &str) -> tk::Result<Vec<tk::Token>> {
-        self.model.tokenize(sequence)
+        self.model.read().unwrap().tokenize(sequence)
     }
 
     fn token_to_id(&self, token: &str) -> Option<u32> {
-        self.model.token_to_id(token)
+        self.model.read().unwrap().token_to_id(token)
     }
 
     fn id_to_token(&self, id: u32) -> Option<String> {
-        self.model.id_to_token(id)
+        self.model.read().unwrap().id_to_token(id)
     }
 
     fn get_vocab(&self) -> std::collections::HashMap<String, u32> {
-        self.model.get_vocab()
+        self.model.read().unwrap().get_vocab()
     }
 
     fn get_vocab_size(&self) -> usize {
-        self.model.get_vocab_size()
+        self.model.read().unwrap().get_vocab_size()
     }
 
     fn save(
@@ -39,11 +39,11 @@ impl tk::Model for RustBpe {
         folder: &std::path::Path,
         prefix: Option<&str>,
     ) -> tk::Result<Vec<std::path::PathBuf>> {
-        self.model.save(folder, prefix)
+        self.model.read().unwrap().save(folder, prefix)
     }
 
     fn get_trainer(&self) -> <Self as tk::Model>::Trainer {
-        self.model.get_trainer()
+        self.model.read().unwrap().get_trainer().into()
     }
 }
 
@@ -102,12 +102,12 @@ impl RustBpe {
         let bpe = builder.build()?;
 
         Ok(Self {
-            model: Arc::new(bpe),
+            model: Arc::new(RwLock::new(bpe)),
         })
     }
 
     pub fn get_unk_token(&self) -> Option<String> {
-        self.model.get_unk_token().clone()
+        self.model.read().unwrap().get_unk_token().clone()
     }
 }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -53,10 +53,10 @@ impl RustTokenizer {
         Ok(Arc::new(RustEncoding::new(Arc::new(encoding))))
     }
 
-    fn train(&self, files: Vec<String>, trainer: Option<Arc<RustBpeTrainer>>) -> Result<()> {
+    pub fn train(&self, files: Vec<String>, trainer: Option<Arc<RustBpeTrainer>>) -> Result<()> {
         let mut trainer = trainer.map_or_else(
             || self.tokenizer.read().unwrap().get_model().get_trainer(),
-            |t| t.trainer,
+            |t| t.as_ref().clone(),
         );
 
         self.tokenizer
@@ -64,9 +64,7 @@ impl RustTokenizer {
             .unwrap()
             .train_from_files(&mut trainer, files)
             .map(|_| {})
-            .map_err(|e| {
-                TokenizersError::ValueError("`vocab` and `merges` must be both specified".into())
-            })
+            .map_err(|e| TokenizersError::Exception(format!("train: {}", e)))
     }
 
     pub fn get_pre_tokenizer(&self) -> Option<Arc<RustWhitespace>> {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,8 +1,10 @@
-use crate::{RustBpe, RustWhitespace};
+use crate::{RustBpe, RustBpeTrainer, RustWhitespace, TokenizersError};
 
 use super::error::Result;
 use std::sync::{Arc, RwLock};
-use tk::{AddedToken, DecoderWrapper, NormalizerWrapper, PostProcessorWrapper, TokenizerImpl};
+use tk::{
+    AddedToken, DecoderWrapper, Model, NormalizerWrapper, PostProcessorWrapper, TokenizerImpl,
+};
 use tokenizers as tk;
 
 type Tokenizer =
@@ -49,6 +51,22 @@ impl RustTokenizer {
             .encode_char_offsets(input, add_special_tokens)?;
 
         Ok(Arc::new(RustEncoding::new(Arc::new(encoding))))
+    }
+
+    fn train(&self, files: Vec<String>, trainer: Option<Arc<RustBpeTrainer>>) -> Result<()> {
+        let mut trainer = trainer.map_or_else(
+            || self.tokenizer.read().unwrap().get_model().get_trainer(),
+            |t| t.trainer,
+        );
+
+        self.tokenizer
+            .write()
+            .unwrap()
+            .train_from_files(&mut trainer, files)
+            .map(|_| {})
+            .map_err(|e| {
+                TokenizersError::ValueError("`vocab` and `merges` must be both specified".into())
+            })
     }
 
     pub fn get_pre_tokenizer(&self) -> Option<Arc<RustWhitespace>> {

--- a/src/trainers.rs
+++ b/src/trainers.rs
@@ -2,12 +2,37 @@ use std::sync::Arc;
 
 use crate::{
     error::{Result, TokenizersError},
-    RustAddedToken,
+    RustAddedToken, RustBpe,
 };
-use tk::models::bpe::BpeTrainer;
+use tk::{
+    models::bpe::{BpeTrainer, BPE},
+    Trainer,
+};
 use tokenizers as tk;
+
 pub struct RustBpeTrainer {
     trainer: Arc<BpeTrainer>,
+}
+
+impl Trainer for RustBpeTrainer {
+    type Model = RustBpe;
+
+    fn should_show_progress(&self) -> bool {
+        self.trainer.should_show_progress()
+    }
+
+    fn train(&self, model: &mut Self::Model) -> tk::Result<Vec<tk::AddedToken>> {
+        self.trainer.train(model)
+    }
+
+    fn feed<I, S, F>(&mut self, iterator: I, process: F) -> tk::Result<()>
+    where
+        I: Iterator<Item = S> + Send,
+        S: AsRef<str> + Send,
+        F: Fn(&str) -> tk::Result<Vec<String>> + Sync,
+    {
+        self.feed(iterator, process)
+    }
 }
 
 impl RustBpeTrainer {


### PR DESCRIPTION
From [Quicktour](https://huggingface.co/docs/tokenizers/quicktour), I would like to make the code below work in tokenizer-swift.

```python
files = [f"data/wikitext-103-raw/wiki.{split}.raw" for split in ["test", "train", "valid"]]
tokenizer.train(files, trainer)
```