### PR TITLE
Implement `Tokenizer.save()`

### DIFF
--- a/Sources/Tokenizers/Tokenizers.swift
+++ b/Sources/Tokenizers/Tokenizers.swift
@@ -96,6 +96,18 @@ public class Tokenizer {
     public func train(files: [String], trainer: BPETrainer? = nil) throws {
         try self.tokenizer.train(files: files, trainer: trainer?.trainer)
     }
+
+    /// - Save`Tokenizer` to the file at the given path.
+    ///
+    /// - Parameters:
+    ///     - path:
+    ///         A path to a file in which to save the serialized tokenizer.
+    ///
+    ///     - pretty:
+    ///         Whether the JSON file should be pretty formatted.
+    public func save(to path: String, pretty: Bool = true) throws {
+        try self.tokenizer.save(path: path, pretty: pretty)
+    }
 }
 
 public struct Encoding {

--- a/src/lib.udl
+++ b/src/lib.udl
@@ -27,6 +27,9 @@ interface RustTokenizer {
   [Throws=TokenizersError]
   void train(sequence<string> files, RustBpeTrainer? trainer);
 
+  [Throws=TokenizersError]
+  void save([ByRef] string path, boolean pretty);
+
   RustWhitespace? get_pre_tokenizer();
 
   void set_pre_tokenizer(RustWhitespace pre_tokenizer);

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -67,6 +67,14 @@ impl RustTokenizer {
             .map_err(|e| TokenizersError::Exception(format!("train: {}", e)))
     }
 
+    pub fn save(&self, path: &str, pretty: bool) -> Result<()> {
+        self.tokenizer
+            .read()
+            .unwrap()
+            .save(path, pretty)
+            .map_err(|e| TokenizersError::Exception(format!("save: {}", e)))
+    }
+
     pub fn get_pre_tokenizer(&self) -> Option<Arc<RustWhitespace>> {
         self.tokenizer
             .read()


### PR DESCRIPTION
From [Quicktour](https://huggingface.co/docs/tokenizers/quicktour), I would like to make the code below work in tokenizer-swift.

```python
tokenizer.save("data/tokenizer-wiki.json")
```