### PR TITLE
Add `Tokenizer.from_file()`

### DIFF
--- a/Sources/Tokenizers/Tokenizers.swift
+++ b/Sources/Tokenizers/Tokenizers.swift
@@ -21,6 +21,19 @@ public class Tokenizer {
         self.tokenizer = RustTokenizer(model: model.model)
     }
 
+    /// - Instantiate `Tokenizer` from the file at the given path.
+    ///
+    /// - Parameters:
+    ///     - path:
+    ///         A path to a local JSON file representing a previously serialized
+    ///         `Tokenizer`
+    ///
+    /// - Return:
+    ///     The new tokenizer
+    public init(contentsOfFile path: String) throws {
+        self.tokenizer = try RustTokenizer.fromFile(path: path)
+    }
+
     /// Instantiate a new ``Tokenizer`` from an existing file on the
     /// Hugging Face Hub.
     ///

--- a/src/lib.udl
+++ b/src/lib.udl
@@ -15,6 +15,9 @@ enum TokenizersError {
 interface RustTokenizer {
   constructor(RustBpe model);
 
+  [Name=from_file, Throws=TokenizersError]
+  constructor([ByRef] string path);
+
   [Name=from_pretrained, Throws=TokenizersError]
   constructor(
     [ByRef] string identifier,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -67,20 +67,16 @@ impl RustTokenizer {
             |t| t.as_ref().clone(),
         );
 
-        self.tokenizer
+        Ok(self
+            .tokenizer
             .write()
             .unwrap()
             .train_from_files(&mut trainer, files)
-            .map(|_| {})
-            .map_err(|e| TokenizersError::Exception(format!("train: {}", e)))
+            .map(|_| {})?)
     }
 
     pub fn save(&self, path: &str, pretty: bool) -> Result<()> {
-        self.tokenizer
-            .read()
-            .unwrap()
-            .save(path, pretty)
-            .map_err(|e| TokenizersError::Exception(format!("save: {}", e)))
+        Ok(self.tokenizer.read().unwrap().save(path, pretty)?)
     }
 
     pub fn get_pre_tokenizer(&self) -> Option<Arc<RustWhitespace>> {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -23,6 +23,14 @@ impl RustTokenizer {
         }
     }
 
+    pub fn from_file(path: &str) -> Result<Self> {
+        let tokenizer = Tokenizer::from_file(path)?;
+
+        Ok(Self {
+            tokenizer: Arc::new(RwLock::new(tokenizer)),
+        })
+    }
+
     pub fn from_pretrained(
         identifier: &str,
         revision: String,

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,4 +1,4 @@
-use crate::{RustBpe, RustBpeTrainer, RustWhitespace, TokenizersError};
+use crate::{RustBpe, RustBpeTrainer, RustWhitespace};
 
 use super::error::Result;
 use std::sync::{Arc, RwLock};


### PR DESCRIPTION
From [Quicktour](https://huggingface.co/docs/tokenizers/quicktour), I would like to make the code below work in tokenizer-swift.

```python
tokenizer = Tokenizer.from_file("data/tokenizer-wiki.json")

```